### PR TITLE
docs: update CodiMD compatibility notice to point to standalone codimd-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@
 
 ## v2 notice
 
-`hackmd-cli` v2 now only supports the official HackMD instance([hackmd.io](https://hackmd.io)) and HackMD EE instances after version `1.38.1`. CodiMD is not supported anymore. If you want to use the CLI tools with CodiMD, please check out the [`v1.x` README](https://github.com/hackmdio/hackmd-cli/tree/v1.2.0) and follow the instruction there.
+`hackmd-cli` v2 now only supports the official HackMD instance ([hackmd.io](https://hackmd.io)) and HackMD EE instances after version `1.38.1`. CodiMD is not supported in this package.
+
+**CodiMD users:** A dedicated standalone CLI is now available at [hackmdio/codimd-cli](https://github.com/hackmdio/codimd-cli). Please refer to that repository for installation and usage instructions.
 
 ### Migrating from v1.x
 
-1. If you are using the CLI with CodiMD, please follow the [`v1.x` README](https://github.com/hackmdio/hackmd-cli/tree/v1.2.0)
+1. If you are using the CLI with CodiMD, please use the standalone [codimd-cli](https://github.com/hackmdio/codimd-cli) instead.
 2. If you are using the CLI with HackMD([hackmd.io](https://hackmd.io)) or HackMD EE(Enterprise Edition) instances:
     * **You're using the JSON file-based config**: Remove `~/.hackmd/config.json` and start over again. You can start with [configuration](#configuration) section.
     * **You're using environment variable based config**: `HMD_CLI_SERVER_URL` has been replaced with `HMD_API_ENDPOINT_URL`. And `HMD_API_ENDPOINT_URL` may vary depending on your instance. Please check contact your instance admin to get the correct `HMD_API_ENDPOINT_URL`. For generating access token, please check the [configuration](#configuration) section. You'll need to set the `HMD_API_ACCESS_TOKEN` environment variable.


### PR DESCRIPTION
## Summary

- Replaces the outdated CodiMD guidance (which pointed to the `v1.x` branch of this repo) with a reference to the new standalone [`codimd-cli`](https://github.com/hackmdio/codimd-cli) repository.
- Removes the `npm install -g codimd-cli` instruction since the package is not yet published on npm.
- Updates the "Migrating from v1.x" section accordingly.


Made with [Cursor](https://cursor.com)