### PR TITLE
Add develop branch npm prerelease publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,14 +4,17 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - develop
 
 permissions:
   id-token: write  # Required for OIDC
-  contents: read
+  contents: write  # Required for GitHub pre-releases
 
 jobs:
-  publish:
-    name: Publish to npm
+  publish-release:
+    name: Release (tag)
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
 
     steps:
@@ -40,4 +43,71 @@ jobs:
         run: pnpm run test
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --access public
+
+  publish-prerelease:
+    name: Pre-release (develop)
+    if: github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.0
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate pre-release version
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          PRE_RELEASE_VERSION="${CURRENT_VERSION}-beta.${TIMESTAMP}.${SHORT_SHA}"
+          echo "Pre-release version: $PRE_RELEASE_VERSION"
+          echo "PRE_RELEASE_VERSION=$PRE_RELEASE_VERSION" >> "$GITHUB_ENV"
+          npm version "$PRE_RELEASE_VERSION" --no-git-tag-version
+
+      - name: Build project
+        run: pnpm run build
+
+      - name: Run tests
+        run: pnpm run test
+
+      - name: Publish pre-release to npm
+        run: npm publish --tag beta --access public
+
+      - name: Create GitHub pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${PRE_RELEASE_VERSION}" \
+            --title "Pre-release v${PRE_RELEASE_VERSION}" \
+            --notes "Pre-release from develop branch.
+
+          - Commit: ${{ github.sha }}
+          - Branch: ${{ github.ref_name }}
+
+          Install with:
+          \`\`\`bash
+          npm install -g @hackmd/hackmd-cli@beta
+          \`\`\`" \
+            --prerelease


### PR DESCRIPTION
## Summary
- Extend the publish workflow to run beta prereleases on pushes to `develop`
- Keep stable releases on `v*` tags publishing to npm `latest`
- Create GitHub pre-releases for each develop build, matching the `@hackmd/api` pattern

## Test plan
- [ ] Merge and verify the `Pre-release (develop)` job publishes to npm with the `beta` tag
- [ ] Confirm install works: `npm install -g @hackmd/hackmd-cli@beta`
- [ ] Confirm stable tag releases still publish to `latest` unchanged


Made with [Cursor](https://cursor.com)