### PR TITLE
fix: preserve note permission flags

### DIFF
--- a/src/commands/notes/create.ts
+++ b/src/commands/notes/create.ts
@@ -47,10 +47,10 @@ raUuSTetT5uQbqQfLnz9lA A new note                       gvfz2UB5THiKABQJQnLs6Q n
     editor,
     help: Flags.help({char: 'h'}),
     parentFolderId,
-    readPermission: notePermission,
+    readPermission: notePermission(),
     tags: noteTags,
     title: noteTitle,
-    writePermission: notePermission,
+    writePermission: notePermission(),
     ...ux.table.flags(),
   }
 

--- a/src/commands/notes/update.ts
+++ b/src/commands/notes/update.ts
@@ -21,9 +21,9 @@ export default class Update extends HackMDCommand {
     noteId,
     parentFolderId,
     permalink,
-    readPermission: notePermission,
+    readPermission: notePermission(),
     tags: noteTags,
-    writePermission: notePermission,
+    writePermission: notePermission(),
   }
 
   async run() {

--- a/src/commands/team-notes/create.ts
+++ b/src/commands/team-notes/create.ts
@@ -37,11 +37,11 @@ raUuSTetT5uQbqQfLnz9lA A new note                       gvfz2UB5THiKABQJQnLs6Q n
     editor,
     help: Flags.help({char: 'h'}),
     parentFolderId,
-    readPermission: notePermission,
+    readPermission: notePermission(),
     tags: noteTags,
     teamPath,
     title: noteTitle,
-    writePermission: notePermission,
+    writePermission: notePermission(),
     ...ux.table.flags(),
   }
 

--- a/src/commands/team-notes/update.ts
+++ b/src/commands/team-notes/update.ts
@@ -21,10 +21,10 @@ export default class Update extends HackMDCommand {
     noteId,
     parentFolderId,
     permalink,
-    readPermission: notePermission,
+    readPermission: notePermission(),
     tags: noteTags,
     teamPath,
-    writePermission: notePermission,
+    writePermission: notePermission(),
   }
 
   async run() {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -43,7 +43,7 @@ export const folderOrder = Flags.string({
   description: 'folder order JSON, e.g. {"root":["folder-id"]}',
 })
 
-export const notePermission = Flags.string({
+export const notePermission = () => Flags.string({
   description: 'set note permission: owner, signed_in, guest',
 })
 

--- a/test/note-permission-flags.test.ts
+++ b/test/note-permission-flags.test.ts
@@ -1,0 +1,49 @@
+import {Parser} from '@oclif/core'
+import {expect} from 'chai'
+
+import CreateNote from '../src/commands/notes/create'
+import UpdateNote from '../src/commands/notes/update'
+import CreateTeamNote from '../src/commands/team-notes/create'
+import UpdateTeamNote from '../src/commands/team-notes/update'
+
+const commands = [
+  ['notes create', CreateNote],
+  ['notes update', UpdateNote],
+  ['team-notes create', CreateTeamNote],
+  ['team-notes update', UpdateTeamNote],
+] as const
+
+describe('Note permission flags', () => {
+  for (const [name, command] of commands) {
+    it(`preserves different read and write permissions for ${name}`, async () => {
+      const {flags} = await Parser.parse(
+        ['--readPermission=guest', '--writePermission=owner'],
+        {
+          flags: {
+            readPermission: command.flags.readPermission,
+            writePermission: command.flags.writePermission,
+          },
+        },
+      )
+
+      expect(flags).to.deep.equal({
+        readPermission: 'guest',
+        writePermission: 'owner',
+      })
+    })
+
+    it(`keeps a lone read permission as readPermission for ${name}`, async () => {
+      const {flags} = await Parser.parse(
+        ['--readPermission=guest'],
+        {
+          flags: {
+            readPermission: command.flags.readPermission,
+            writePermission: command.flags.writePermission,
+          },
+        },
+      )
+
+      expect(flags).to.deep.equal({readPermission: 'guest'})
+    })
+  }
+})


### PR DESCRIPTION
Fixes #106 

Create separate flag definitions for `readPermission` and `writePermission` so their values don’t overwrite each other.