### PR TITLE
Release v2.5.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,12 +50,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "GitHub release ${TAG} already exists, skipping"
             exit 0
           fi
+          NOTES="$(awk -v ver="$VERSION" '
+            $0 == "## " ver {p=1; next}
+            p && /^## / {exit}
+            p
+          ' CHANGELOG.md)"
           gh release create "$TAG" \
             --title "$TAG" \
+            --notes "$NOTES" \
             --generate-notes \
             --latest
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   id-token: write  # Required for OIDC
-  contents: write  # Required for GitHub pre-releases
+  contents: write  # Required for GitHub releases
 
 jobs:
   publish-release:
@@ -44,6 +44,20 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release ${TAG} already exists, skipping"
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --latest
 
   publish-prerelease:
     name: Pre-release (develop)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to HackMD-CLI will be documented in this file.
 
+## 2.5.1
+
+### Added
+
+- `--tags` flag for `notes create`, `notes update`, `team-notes create`, and `team-notes update`
+- Tags column on `notes` and `team-notes` list output
+- `--readPermission`, `--writePermission`, and `--permalink` flags for `notes update` and `team-notes update`
+- Automated npm prereleases and GitHub pre-releases from the `develop` branch
+
+### Changed
+
+- Agent skill now includes workflow verification steps and an error-handling table
+- CodiMD compatibility notice now points to the standalone [codimd-cli](https://github.com/hackmdio/codimd-cli)
+
+### Fixed
+
+- `readPermission` and `writePermission` flags no longer overwrite each other when both are set
+
 ## 2.5.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ npm install -g @hackmd/hackmd-cli
 $ hackmd-cli COMMAND
 running command...
 $ hackmd-cli (--version|-v)
-@hackmd/hackmd-cli/2.5.0 darwin-arm64 node-v26.0.0
+@hackmd/hackmd-cli/2.5.1 darwin-arm64 node-v26.0.0
 $ hackmd-cli --help [COMMAND]
 USAGE
   $ hackmd-cli COMMAND
@@ -179,7 +179,7 @@ EXAMPLES
   # A note to be exported
 ```
 
-_See code: [src/commands/export.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.0/src/commands/export.ts)_
+_See code: [src/commands/export.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.1/src/commands/export.ts)_
 
 ## `hackmd-cli folders`
 
@@ -213,7 +213,7 @@ EXAMPLES
   91722050-bf47-4334-9e5d-87125a724c29 #4F46E5 Project documentation 1F600 engineering fc7a3d48-4a07-4cbf-bf4f-e65dd896e01c
 ```
 
-_See code: [src/commands/folders/index.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.0/src/commands/folders/index.ts)_
+_See code: [src/commands/folders/index.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.1/src/commands/folders/index.ts)_
 
 ## `hackmd-cli folders create`
 
@@ -369,7 +369,7 @@ EXAMPLES
   BnC6gN0_TfStV2KKmPPXeg Welcome to your team's workspace null                   CLI-test
 ```
 
-_See code: [src/commands/history.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.0/src/commands/history.ts)_
+_See code: [src/commands/history.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.1/src/commands/history.ts)_
 
 ## `hackmd-cli login`
 
@@ -391,7 +391,7 @@ EXAMPLES
   Login successfully
 ```
 
-_See code: [src/commands/login.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.0/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.1/src/commands/login.ts)_
 
 ## `hackmd-cli logout`
 
@@ -412,7 +412,7 @@ EXAMPLES
   You've logged out successfully
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.0/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.1/src/commands/logout.ts)_
 
 ## `hackmd-cli notes`
 
@@ -446,7 +446,7 @@ EXAMPLES
   raUuSTetT5uQbqQfLnz9lA CLI test note                    gvfz2UB5THiKABQJQnLs6Q null
 ```
 
-_See code: [src/commands/notes/index.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.0/src/commands/notes/index.ts)_
+_See code: [src/commands/notes/index.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.1/src/commands/notes/index.ts)_
 
 ## `hackmd-cli notes create`
 
@@ -522,18 +522,18 @@ Update note
 
 ```
 USAGE
-  $ hackmd-cli notes update [--content <value>] [-h] [--noteId <value>] [--parentFolderId <value>] [--permalink <value>]
-    [--readPermission <value>] [--tags <value>] [--writePermission <value>]
+  $ hackmd-cli notes update [--content <value>] [-h] [--noteId <value>] [--parentFolderId <value>] [--permalink
+    <value>] [--readPermission <value>] [--tags <value>] [--writePermission <value>]
 
 FLAGS
-  -h, --help                    Show CLI help.
-  --content=<value>             new note content
-  --noteId=<value>              HackMD note id
-  --parentFolderId=<value>      parent folder id
-  --permalink=<value>           note permalink
-  --readPermission=<value>      set note permission: owner, signed_in, guest
-  --tags=<value>                set note tags, comma-separated (e.g. tag1,tag2)
-  --writePermission=<value>     set note permission: owner, signed_in, guest
+  -h, --help                 Show CLI help.
+  --content=<value>          new note content
+  --noteId=<value>           HackMD note id
+  --parentFolderId=<value>   parent folder id
+  --permalink=<value>        note permalink
+  --readPermission=<value>   set note permission: owner, signed_in, guest
+  --tags=<value>             set note tags, comma-separated (e.g. tag1,tag2)
+  --writePermission=<value>  set note permission: owner, signed_in, guest
 
 DESCRIPTION
   Update note
@@ -581,7 +581,7 @@ EXAMPLES
   91722050-bf47-4334-9e5d-87125a724c29 #4F46E5 Team handbook    1F600 team-docs fc7a3d48-4a07-4cbf-bf4f-e65dd896e01c
 ```
 
-_See code: [src/commands/team-folders/index.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.0/src/commands/team-folders/index.ts)_
+_See code: [src/commands/team-folders/index.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.1/src/commands/team-folders/index.ts)_
 
 ## `hackmd-cli team-folders create`
 
@@ -722,7 +722,7 @@ EXAMPLES
   BnC6gN0_TfStV2KKmPPXeg Welcome to your team's workspace null     CLI-test
 ```
 
-_See code: [src/commands/team-notes/index.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.0/src/commands/team-notes/index.ts)_
+_See code: [src/commands/team-notes/index.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.1/src/commands/team-notes/index.ts)_
 
 ## `hackmd-cli team-notes create`
 
@@ -801,19 +801,19 @@ Update team note
 
 ```
 USAGE
-  $ hackmd-cli team-notes update [--content <value>] [-h] [--noteId <value>] [--parentFolderId <value>]
-    [--permalink <value>] [--readPermission <value>] [--tags <value>] [--teamPath <value>] [--writePermission <value>]
+  $ hackmd-cli team-notes update [--content <value>] [-h] [--noteId <value>] [--parentFolderId <value>] [--permalink
+    <value>] [--readPermission <value>] [--tags <value>] [--teamPath <value>] [--writePermission <value>]
 
 FLAGS
-  -h, --help                    Show CLI help.
-  --content=<value>             new note content
-  --noteId=<value>              HackMD note id
-  --parentFolderId=<value>      parent folder id
-  --permalink=<value>           note permalink
-  --readPermission=<value>      set note permission: owner, signed_in, guest
-  --tags=<value>                set note tags, comma-separated (e.g. tag1,tag2)
-  --teamPath=<value>            HackMD team path
-  --writePermission=<value>     set note permission: owner, signed_in, guest
+  -h, --help                 Show CLI help.
+  --content=<value>          new note content
+  --noteId=<value>           HackMD note id
+  --parentFolderId=<value>   parent folder id
+  --permalink=<value>        note permalink
+  --readPermission=<value>   set note permission: owner, signed_in, guest
+  --tags=<value>             set note tags, comma-separated (e.g. tag1,tag2)
+  --teamPath=<value>         HackMD team path
+  --writePermission=<value>  set note permission: owner, signed_in, guest
 
 DESCRIPTION
   Update team note
@@ -859,7 +859,7 @@ EXAMPLES
   f76308a6-d77a-41f6-86d0-8ada426a6fb4 CLI test team CLI-test 82f7f3d9-4079-4c78-8a00-14094272ece9
 ```
 
-_See code: [src/commands/teams.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.0/src/commands/teams.ts)_
+_See code: [src/commands/teams.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.1/src/commands/teams.ts)_
 
 ## `hackmd-cli version`
 
@@ -912,7 +912,7 @@ EXAMPLES
   82f7f3d9-4079-4c78-8a00-14094272ece9 Ming-Hsiu Tsai null  gvfz2UB5THiKABQJQnLs6Q
 ```
 
-_See code: [src/commands/whoami.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.0/src/commands/whoami.ts)_
+_See code: [src/commands/whoami.ts](https://github.com/hackmdio/hackmd-cli/blob/v2.5.1/src/commands/whoami.ts)_
 <!-- commandsstop -->
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hackmd/hackmd-cli",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "author": "HackMD Team",
   "bin": {
     "hackmd-cli": "./bin/run"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares a **2.5.1** patch release from everything merged since `v2.5.0`, and fills the GitHub Release gap in the publish workflow.

### Auto-publish vs GitHub Releases

- **npm is already automatic.** Pushing a `v*` tag runs tests and `npm publish`. Pushes to `develop` already publish `@beta` prereleases.
- **Production GitHub Releases were not automatic.** `v2.5.0` was created by hand in the GitHub UI. Only develop prereleases used `gh release create`.
- This PR adds GitHub Release creation to the tag job. Notes start from the matching `CHANGELOG.md` section, then append GitHub's generated PR list. If a release already exists (for example from the GitHub UI), the step is skipped.
- After merge, tagging `v2.5.1` on `develop` should publish npm **and** open the GitHub Release.

`master` is gone, so this targets `develop` instead of the old `release/*` → `master` flow.

### 2.5.1 contents

- Tags on notes/team-notes create, update, and list (#97)
- `--readPermission`, `--writePermission`, and `--permalink` on note update commands (#97)
- Fix: read/write permission flags no longer overwrite each other (#107)
- Skill verification/error-handling docs (#96)
- CodiMD notice pointing at standalone `codimd-cli` (#101)
- Develop-branch npm prereleases (#103)

## Test plan

- [ ] CI unit and smoke tests pass
- [ ] Review `CHANGELOG.md` for the 2.5.1 entry
- [ ] After merge, tag `v2.5.1` on `develop` to publish npm and create the GitHub Release
- [ ] Confirm the GitHub Release appears at https://github.com/hackmdio/hackmd-cli/releases/tag/v2.5.1
- [ ] Confirm `@hackmd/hackmd-cli@2.5.1` on npm

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-318b6ef5-7cd7-4c42-8414-a7c0e2a962de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-318b6ef5-7cd7-4c42-8414-a7c0e2a962de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

